### PR TITLE
Kernel docker optimisation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-BOX_VERSION := 1.0.0
+BOX_VERSION := 1.1.0
 BOX_NAME := alpine2docker
 BOX_FILE := $(BOX_NAME)-$(BOX_VERSION).box
 BOX_TEST := $(BOX_NAME)-test

--- a/alpine2docker.json
+++ b/alpine2docker.json
@@ -3,7 +3,7 @@
     "variables": {
         "BASE_USER": "alpine",
         "DOCKER_VERSION": "1.13.0",
-        "COMPOSE_VERSION": "1.10.0",
+        "COMPOSE_VERSION": "1.11.1",
         "BOX_VERSION": "latest"
     },
     "builders": [

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,7 +1,18 @@
 #!/bin/sh
 set -eux
 
-# Install Docker
+#### Configure System to handle Docker capabilities
+
+# Make PAX in softmode - example for container with JVM
+cat <<EOF >/etc/sysctl.d/10-docker.conf
+kernel.pax.softmode=1
+EOF
+
+# Enable swap accounting for containers
+sed -i 's/quiet/quiet cgroup_enable=memory swapaccount=1/' /boot/extlinux.conf
+
+
+### Install Docker
 echo 'http://dl-cdn.alpinelinux.org/alpine/edge/community' \
     | tee -a /etc/apk/repositories
 apk update
@@ -14,10 +25,10 @@ addgroup "${BASE_USER}" docker
 service docker start
 rc-update add docker boot
 
-# Install Docker-compose
+### Install Docker-compose
 apk add py-pip
 pip install --no-cache-dir --upgrade pip
 pip install --no-cache-dir "docker-compose==${COMPOSE_VERSION}"
 
-# Docker bash completions
+### Docker bash completions
 apk add docker-bash-completion

--- a/tests/00-box-tests.bats
+++ b/tests/00-box-tests.bats
@@ -2,7 +2,7 @@
 
 BASE_USER=alpine
 DOCKER_VERSION=1.13.0
-COMPOSE_VERSION=1.10.0
+COMPOSE_VERSION=1.11.1
 
 execute_vagrant_ssh_command() {
     vagrant ssh -c "${*}" -- -n -T


### PR DESCRIPTION
* Moving box version to 1.1.0
* Moving docker-compose version to 1.11.0
* Adding Swap support for containers (cgroup swap and meme accounting)
* Making GRSec less aggressive to allow running non alpine linux JVM inside containers