### PR TITLE
Prepare 1.3.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 # CHANGELOG
 
 
-## Not Released Yet (1.3.0)
+## 11/06/2017 (1.3.0)
 
 - From GH-?
-  * Alpine Linux upgraded to 3.6.0
+  * Alpine Linux upgraded to 3.6.1
   * Docker installed from the "community" apk repository
   * VM Default hostname is now "alpine2docker"
   * Apk mirror is now auto selected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 # CHANGELOG
 
 
+## Not Released Yet (1.3.0)
+
+- From GH-?
+  * Alpine Linux upgraded to 3.6.0
+  * Docker installed from the "community" apk repository
+  * VM Default hostname is now "alpine2docker"
+  * Apk mirror is now auto selected
+
+## 20/05/2017 (1.2.1)
+
+- From GH-4:
+  * Alpine Linux to 3.5.2
+  * Rsync is installed for vagrant share
+  * Docker Engine to 17.05_ce
+  * Docker-Compose to 1.13.0
+  * Pax and GrSec settings applied BEFORE customization
+
 ## 26/03/2017 (1.2.0)
 
 - From GH-3:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 11/06/2017 (1.3.0)
 
-- From GH-?
+- From GH-5
   * Alpine Linux upgraded to 3.6.1
   * Docker installed from the "community" apk repository
   * VM Default hostname is now "alpine2docker"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-export BOX_VERSION ?= 1.2.1
+export BOX_VERSION ?= 1.3.0
 export VM_CPUS ?= 1
 export VM_MEMORY ?= 1024
 BOX_BASENAME ?= alpine2docker

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ vagrant up
 
 ## [What's in the box ?](https://www.youtube.com/watch?v=1giVzxyoclE)
 
-* Guest OS: Alpine Linux 3.5
+* Guest OS: Alpine Linux 3.6
 * LVM root filesystem for any filesystem growing allocation
 * 1 Gb swap enabled
 * Default to NAT network

--- a/alpine2docker.json
+++ b/alpine2docker.json
@@ -21,9 +21,9 @@
       "disk_size": 40960,
       "guest_os_type": "Linux26_64",
       "iso_urls": [
-        "https://nl.alpinelinux.org/alpine/v3.5/releases/x86_64/alpine-virt-3.5.2-x86_64.iso"
+        "https://nl.alpinelinux.org/alpine/v3.6/releases/x86_64/alpine-virt-3.6.0_rc1-x86_64.iso"
       ],
-      "iso_checksum": "2258ca975d7b829ea6229d314b2782d4070ec9b7f688392817e562f5a14a34b5",
+      "iso_checksum": "040379f464e619cc597b4d13daed8e5759708d859153942521057ce4634eb768",
       "iso_checksum_type": "sha256",
       "communicator": "ssh",
       "http_directory": "./http",

--- a/alpine2docker.json
+++ b/alpine2docker.json
@@ -21,9 +21,9 @@
       "disk_size": 40960,
       "guest_os_type": "Linux26_64",
       "iso_urls": [
-        "https://nl.alpinelinux.org/alpine/v3.6/releases/x86_64/alpine-virt-3.6.0_rc1-x86_64.iso"
+        "https://nl.alpinelinux.org/alpine/v3.6/releases/x86_64/alpine-virt-3.6.1-x86_64.iso"
       ],
-      "iso_checksum": "040379f464e619cc597b4d13daed8e5759708d859153942521057ce4634eb768",
+      "iso_checksum": "f4421357ed2c969046b95cef6fc4844aeebfe8a2323049915dbe953d5f1d3c36",
       "iso_checksum_type": "sha256",
       "communicator": "ssh",
       "http_directory": "./http",

--- a/http/answers
+++ b/http/answers
@@ -1,5 +1,5 @@
 KEYMAPOPTS="us us"
-HOSTNAMEOPTS="-n alpine35"
+HOSTNAMEOPTS="-n alpine2docker"
 INTERFACESOPTS="auto lo
 iface lo inet loopback
 
@@ -10,7 +10,7 @@ iface eth0 inet dhcp
 DNSOPTS="-d local -n 8.8.8.8 8.8.4.4"
 TIMEZONEOPTS="-z UTC"
 PROXYOPTS="none"
-APKREPOSOPTS="http://dl-cdn.alpinelinux.org/alpine/v3.5/main"
+APKREPOSOPTS="-r"
 SSHDOPTS="-c openssh"
 NTPOPTS="-c openntpd"
 DISKOPTS="-s 1024 -L -m sys /dev/sda"

--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -4,6 +4,10 @@ set -eux -o pipefail
 
 uptime && date
 
+# Adding the community repository
+CURRENT_REPO="$(cat /etc/apk/repositories )"
+echo "${CURRENT_REPO}" | sed 's/main/community/g' | tee -a /etc/apk/repositories
+
 # Update system
 apk upgrade -U --available --no-cache
 

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -16,9 +16,6 @@ sed -i 's/quiet/quiet cgroup_enable=memory swapaccount=1/' /boot/extlinux.conf
 
 
 ### Install Docker
-echo 'http://dl-cdn.alpinelinux.org/alpine/edge/community' \
-    | tee -a /etc/apk/repositories
-
 apk --no-cache add docker py-pip docker-bash-completion
 
 service docker stop

--- a/tests/00-box-tests.bats
+++ b/tests/00-box-tests.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 
 BASE_USER=alpine
+OS_TYPE="Alpine"
+OS_VERSION="3.6"
 
 execute_vagrant_ssh_command() {
     vagrant ssh -c "${*}" -- -n -T
@@ -28,6 +30,16 @@ execute_vagrant_ssh_command() {
 @test "We have the passwordless sudoers rights inside the VM" {
     execute_vagrant_ssh_command 'sudo whoami' | grep root
 }
+
+@test "Remote VM runs on ${OS_TYPE}, version ${OS_VERSION}" {
+    execute_vagrant_ssh_command "grep NAME /etc/os-release | grep ${OS_TYPE} \
+    && grep VERSION /etc/os-release | grep ${OS_VERSION}"
+}
+
+@test "The GRSec Kernel feature named PAX is in safemode to allows mem_alloc for JVM containers" {
+    [ "$(execute_vagrant_ssh_command 'sudo cat /proc/sys/kernel/pax/softmode')" -eq 1 ]
+}
+
 
 @test "SSH does not allow root login" {
     [ "$(execute_vagrant_ssh_command \


### PR DESCRIPTION
This PR introduces: 

- Alpine Linux Base OS to 3.6.1
- Docker package is now coming from community APK repo (and not edge anymore)
- VM Default hostname is now "alpine2docker"
- APK auto-mirror at build for improving build performances
