### PR TITLE
Bump to Alpine 3.9.4 + Docker-compose 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 02/06/2019 (1.7.0)
 
 - Bump Alpine Linux to 3.9.4
+- Bump Docker to 18.09.1
+- Bump Docker-compose to 1.24.0
 
 ## 13/01/2019 (1.6.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 02/06/2019 (1.7.0)
+
+- Bump Alpine Linux to 3.9.4
+
 ## 13/01/2019 (1.6.2)
 
 - Upgrade to Alpine Linux 3.8.2

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-export BOX_VERSION ?= 1.6.2
+export BOX_VERSION ?= 1.7.0
 export VM_CPUS ?= 1
 export VM_MEMORY ?= 1024
 BOX_BASENAME ?= alpine2docker

--- a/alpine2docker.json
+++ b/alpine2docker.json
@@ -21,9 +21,9 @@
       "disk_size": 40960,
       "guest_os_type": "Linux26_64",
       "iso_urls": [
-        "http://dl-cdn.alpinelinux.org/alpine/v3.8/releases/x86_64/alpine-virt-3.8.2-x86_64.iso"
+        "http://dl-cdn.alpinelinux.org/alpine/v3.9/releases/x86_64/alpine-virt-3.9.4-x86_64.iso"
       ],
-      "iso_checksum": "77a609dd710ba0d3b0806a314f5c4ef1718ce140b522bf7c7ca081eba664db2c",
+      "iso_checksum": "4122dce1092564aa88415c21702d6cb973a7d29f91658d24316f7f0aac3a6761",
       "iso_checksum_type": "sha256",
       "communicator": "ssh",
       "http_directory": "./http",

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -11,7 +11,7 @@ sed -i 's/quiet/quiet cgroup_enable=memory swapaccount=1/' /boot/extlinux.conf
 
 
 ### Install Docker
-apk --no-cache add docker py-pip docker-bash-completion
+apk --no-cache add docker docker-bash-completion
 
 service docker stop
 addgroup root docker
@@ -20,8 +20,9 @@ service docker start
 rc-update add docker boot
 
 ### Install Docker-compose
-pip install --no-cache-dir --upgrade pip
-pip install --no-cache-dir "docker-compose"
+apk add --no-cache py3-pip py3-paramiko
+pip3 install --no-cache-dir --upgrade pip
+pip3 install --no-cache-dir "docker-compose==1.24.0"
 
 ### Reboot now
 reboot now

--- a/tests/00-box-tests.bats
+++ b/tests/00-box-tests.bats
@@ -2,7 +2,7 @@
 
 BASE_USER=alpine
 OS_TYPE="Alpine"
-OS_VERSION="3.8"
+OS_VERSION="3.9"
 
 execute_vagrant_ssh_command() {
     vagrant ssh -c "${*}" -- -n -T


### PR DESCRIPTION
This PR introduces the following changes:

- Bump Alpine Linux to 3.9.4
- Bump Docker to 18.09.1
- Fix docker-compose pip install (new dependency to `py3-paramiko` to add or `pip install fails` since `1.24.0`)
- Bump Docker-compose to 1.24.0